### PR TITLE
fix: set Bachs initial package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,11 @@
 {
   "name": "sails-pay",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "version": "0.2.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -14,8 +16,7 @@
         "husky": "^8.0.3",
         "lint-staged": "^15.2.0",
         "prettier": "3.1.1"
-      },
-      "version": "0.2.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
@@ -3019,7 +3020,7 @@
     },
     "packages/sails-bachs": {
       "name": "@sails-pay/bachs",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "machine": "^15.2.3",
@@ -3080,6 +3081,5 @@
         "undici": "^6.19.2"
       }
     }
-  },
-  "version": "0.2.0"
+  }
 }

--- a/packages/sails-bachs/package.json
+++ b/packages/sails-bachs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sails-pay/bachs",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Bachs adapter for Sails Pay",
   "main": "adapter.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- set @sails-pay/bachs to 0.0.1 for its first npm release
- update package-lock metadata to match

## Verification
- npm test --workspace @sails-pay/bachs
- npm --cache /private/tmp/npm-cache publish --workspace @sails-pay/bachs --dry-run