### PR TITLE
feat(bachs): support complete ad-hoc item pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Create a product checkout session with camelCase inputs:
 
 ```js
 const checkoutUrl = await sails.pay.checkout({
-  items: [{ product: 'prod_abc123', quantity: 1 }],
+  items: [{ product: 'prod_abc123' }],
   customer: {
     email: 'customer@example.com',
     name: 'Jane Doe'
@@ -57,6 +57,73 @@ The adapter maps those inputs to Bachs Checkout Sessions internally:
 `items` becomes `product_cart`, `product` becomes `product_id`,
 `returnUrl` becomes `return_url`, and `idempotencyKey` becomes the
 `Idempotency-Key` header.
+
+### Bachs ad-hoc item pricing
+
+Override a catalog product with a fixed price for one checkout using the
+`amount` shorthand:
+
+```js
+const checkoutUrl = await sails.pay.checkout({
+  items: [{ product: 'prod_abc123', amount: '19.00' }]
+})
+```
+
+For pay-what-you-want pricing, provide camel-cased custom bounds. When using
+Bachs' hosted checkout, omit `chosenAmount` and let the buyer select an amount
+on the hosted page:
+
+```js
+const checkoutUrl = await sails.pay.checkout({
+  items: [
+    {
+      product: 'prod_abc123',
+      pricing: {
+        type: 'custom',
+        presetAmount: '10.00',
+        minimumAmount: '5.00',
+        maximumAmount: '100.00'
+      }
+    }
+  ]
+})
+```
+
+When the buyer already selected an amount in your own UI, pass it separately
+as `chosenAmount`:
+
+```js
+const checkoutUrl = await sails.pay.checkout({
+  items: [
+    {
+      product: 'prod_abc123',
+      pricing: {
+        type: 'custom',
+        minimumAmount: '5.00',
+        maximumAmount: '100.00'
+      },
+      chosenAmount: '12.00'
+    }
+  ]
+})
+```
+
+Use `free` pricing when no money should be collected:
+
+```js
+const checkoutUrl = await sails.pay.checkout({
+  items: [
+    {
+      product: 'prod_abc123',
+      pricing: { type: 'free' }
+    }
+  ]
+})
+```
+
+All money values must be decimal strings such as `'19.00'`, never JavaScript
+numbers or minor units. `quantity` is optional and Bachs defaults it to `1`;
+when supplied, it must be an integer of at least `1`.
 
 Look up the returned checkout after redirect or webhook processing:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3020,7 +3020,7 @@
     },
     "packages/sails-bachs": {
       "name": "@sails-pay/bachs",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "machine": "^15.2.3",
@@ -3045,7 +3045,7 @@
       }
     },
     "packages/sails-pay": {
-      "version": "0.1.0",
+      "version": "0.2.2",
       "license": "MIT",
       "peerDependencies": {
         "@sails-pay/bachs": "*",

--- a/packages/sails-bachs/helpers/payloads.js
+++ b/packages/sails-bachs/helpers/payloads.js
@@ -44,13 +44,22 @@ function buildProductCart(items) {
     return undefined
   }
 
-  return items.map((item) =>
-    withoutUndefined({
+  return items.map((item) => {
+    const pricing =
+      item.amount !== undefined
+        ? normalizePricing({
+            type: 'fixed',
+            amount: item.amount
+          })
+        : normalizePricing(item.pricing)
+
+    return withoutUndefined({
       product_id: item.product || item.productId,
       quantity: item.quantity,
-      amount: item.amount
+      pricing,
+      amount: item.chosenAmount
     })
-  )
+  })
 }
 
 function buildCheckoutSessionPayload(inputs, adapterConfig = {}) {
@@ -76,25 +85,44 @@ function buildCheckoutSessionPayload(inputs, adapterConfig = {}) {
   })
 }
 
-function buildPricingPayload(inputs) {
-  let pricing
-
-  if (inputs.pricing) {
-    const { currencyOptions, ...pricingInput } = inputs.pricing
-
-    pricing = withoutUndefined({
-      ...pricingInput,
-      currency_options: currencyOptions || inputs.currencyOptions
-    })
-  } else {
-    pricing = withoutUndefined({
-      currency: inputs.currency,
-      amount: inputs.amount,
-      currency_options: inputs.currencyOptions
-    })
+function normalizePricing(pricing, fallbackCurrencyOptions) {
+  if (!pricing || typeof pricing !== 'object' || Array.isArray(pricing)) {
+    return undefined
   }
 
-  return Object.keys(pricing).length > 0 ? pricing : undefined
+  const {
+    type,
+    presetAmount,
+    minimumAmount,
+    maximumAmount,
+    currencyOptions,
+    ...pricingInput
+  } = pricing
+  const normalizedPricing = withoutUndefined({
+    ...pricingInput,
+    price_type: type,
+    preset_amount: presetAmount,
+    minimum_amount: minimumAmount,
+    maximum_amount: maximumAmount,
+    currency_options:
+      currencyOptions === undefined ? fallbackCurrencyOptions : currencyOptions
+  })
+
+  return Object.keys(normalizedPricing).length > 0
+    ? normalizedPricing
+    : undefined
+}
+
+function buildPricingPayload(inputs) {
+  if (inputs.pricing) {
+    return normalizePricing(inputs.pricing, inputs.currencyOptions)
+  }
+
+  return normalizePricing({
+    currency: inputs.currency,
+    amount: inputs.amount,
+    currencyOptions: inputs.currencyOptions
+  })
 }
 
 function buildPureCheckoutPayload(inputs, adapterConfig = {}) {
@@ -142,5 +170,6 @@ module.exports = {
   buildRefundPayload,
   buildProductCart,
   buildCustomerPayload,
+  normalizePricing,
   withoutUndefined
 }

--- a/packages/sails-bachs/helpers/validate-checkout-items.js
+++ b/packages/sails-bachs/helpers/validate-checkout-items.js
@@ -1,0 +1,177 @@
+const pricingTypes = new Set(['fixed', 'custom', 'free'])
+const pricingMoneyFields = [
+  'amount',
+  'presetAmount',
+  'minimumAmount',
+  'maximumAmount'
+]
+const customPricingFields = ['presetAmount', 'minimumAmount', 'maximumAmount']
+const decimalStringPattern = /^\d+(?:\.\d+)?$/
+
+function fieldWasProvided(object, field) {
+  return object[field] !== undefined
+}
+
+function invalid(field, message) {
+  return {
+    field,
+    message: `${field} ${message}`
+  }
+}
+
+function validateMoney(value, field) {
+  if (typeof value !== 'string' || !decimalStringPattern.test(value)) {
+    return invalid(field, 'must be a non-negative decimal string.')
+  }
+}
+
+function validatePricingMoney(pricing, itemPath) {
+  for (const field of pricingMoneyFields) {
+    if (fieldWasProvided(pricing, field)) {
+      const error = validateMoney(
+        pricing[field],
+        `${itemPath}.pricing.${field}`
+      )
+
+      if (error) {
+        return error
+      }
+    }
+  }
+}
+
+function validateItem(item, index) {
+  const itemPath = `items[${index}]`
+
+  if (!item || typeof item !== 'object' || Array.isArray(item)) {
+    return invalid(itemPath, 'must be an object.')
+  }
+
+  if (
+    fieldWasProvided(item, 'quantity') &&
+    (!Number.isInteger(item.quantity) || item.quantity < 1)
+  ) {
+    return invalid(`${itemPath}.quantity`, 'must be an integer of at least 1.')
+  }
+
+  const hasAmount = fieldWasProvided(item, 'amount')
+  const hasPricing = fieldWasProvided(item, 'pricing')
+  const hasChosenAmount = fieldWasProvided(item, 'chosenAmount')
+
+  if (hasAmount && hasPricing) {
+    return invalid(
+      itemPath,
+      'must not provide both amount and pricing; amount is the fixed-price shorthand.'
+    )
+  }
+
+  if (hasAmount) {
+    const error = validateMoney(item.amount, `${itemPath}.amount`)
+
+    if (error) {
+      return error
+    }
+
+    if (hasChosenAmount) {
+      return invalid(
+        `${itemPath}.chosenAmount`,
+        'can only be used with catalog custom pricing or ad-hoc custom pricing.'
+      )
+    }
+  }
+
+  if (hasChosenAmount) {
+    const error = validateMoney(item.chosenAmount, `${itemPath}.chosenAmount`)
+
+    if (error) {
+      return error
+    }
+  }
+
+  if (!hasPricing) {
+    return
+  }
+
+  if (
+    !item.pricing ||
+    typeof item.pricing !== 'object' ||
+    Array.isArray(item.pricing)
+  ) {
+    return invalid(`${itemPath}.pricing`, 'must be an object.')
+  }
+
+  const pricing = item.pricing
+
+  if (!pricingTypes.has(pricing.type)) {
+    return invalid(
+      `${itemPath}.pricing.type`,
+      'must be fixed, custom, or free.'
+    )
+  }
+
+  if (pricing.type === 'fixed') {
+    if (!fieldWasProvided(pricing, 'amount')) {
+      return invalid(
+        `${itemPath}.pricing.amount`,
+        'is required for fixed pricing.'
+      )
+    }
+
+    const customField = customPricingFields.find((field) =>
+      fieldWasProvided(pricing, field)
+    )
+
+    if (customField) {
+      return invalid(
+        `${itemPath}.pricing.${customField}`,
+        'is not allowed with fixed pricing.'
+      )
+    }
+
+    if (hasChosenAmount) {
+      return invalid(
+        `${itemPath}.chosenAmount`,
+        'can only be used with catalog custom pricing or ad-hoc custom pricing.'
+      )
+    }
+  }
+
+  if (pricing.type === 'custom' && fieldWasProvided(pricing, 'amount')) {
+    return invalid(
+      `${itemPath}.pricing.amount`,
+      'is not allowed with custom pricing.'
+    )
+  }
+
+  if (pricing.type === 'free') {
+    const monetaryField = pricingMoneyFields.find((field) =>
+      fieldWasProvided(pricing, field)
+    )
+
+    if (monetaryField) {
+      return invalid(
+        `${itemPath}.pricing.${monetaryField}`,
+        'is not allowed with free pricing.'
+      )
+    }
+
+    if (hasChosenAmount) {
+      return invalid(
+        `${itemPath}.chosenAmount`,
+        'is not allowed with free pricing.'
+      )
+    }
+  }
+
+  return validatePricingMoney(pricing, itemPath)
+}
+
+module.exports = function validateCheckoutItems(items) {
+  for (let index = 0; index < items.length; index++) {
+    const error = validateItem(items[index], index)
+
+    if (error) {
+      return error
+    }
+  }
+}

--- a/packages/sails-bachs/machines/checkout.js
+++ b/packages/sails-bachs/machines/checkout.js
@@ -3,6 +3,7 @@ const {
   buildCheckoutSessionPayload,
   buildPureCheckoutPayload
 } = require('../helpers/payloads')
+const validateCheckoutItems = require('../helpers/validate-checkout-items')
 const parameters = require('../helpers/parameters')
 
 module.exports = require('machine').build({
@@ -16,7 +17,7 @@ module.exports = require('machine').build({
     items: {
       type: 'ref',
       description:
-        'Product items for Bachs Checkout Sessions. Each item should use product or productId plus optional quantity and amount.'
+        'Product items for Bachs Checkout Sessions. Supports catalog pricing, fixed amount shorthand, advanced pricing, and chosenAmount.'
     },
     productCollectionId: {
       type: 'string',
@@ -141,10 +142,6 @@ module.exports = require('machine').build({
       inputs.productCollectionId || inputs.productCollection
     )
     const shouldUseCheckoutSession = hasItems || hasProductCollection
-    const path = shouldUseCheckoutSession ? '/checkout-sessions' : '/checkouts'
-    const payload = shouldUseCheckoutSession
-      ? buildCheckoutSessionPayload(inputs, adapterConfig)
-      : buildPureCheckoutPayload(inputs, adapterConfig)
 
     if (shouldUseCheckoutSession && hasItems === hasProductCollection) {
       return exits.invalidRequest({
@@ -152,6 +149,19 @@ module.exports = require('machine').build({
           'Provide exactly one of items or productCollectionId for a Bachs checkout session.'
       })
     }
+
+    if (hasItems) {
+      const validationError = validateCheckoutItems(inputs.items)
+
+      if (validationError) {
+        return exits.invalidRequest(validationError)
+      }
+    }
+
+    const path = shouldUseCheckoutSession ? '/checkout-sessions' : '/checkouts'
+    const payload = shouldUseCheckoutSession
+      ? buildCheckoutSessionPayload(inputs, adapterConfig)
+      : buildPureCheckoutPayload(inputs, adapterConfig)
 
     if (!shouldUseCheckoutSession && !payload.pricing) {
       return exits.invalidRequest({

--- a/packages/sails-bachs/package.json
+++ b/packages/sails-bachs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sails-pay/bachs",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "Bachs adapter for Sails Pay",
   "main": "adapter.js",
   "scripts": {

--- a/packages/sails-bachs/test/checkout.test.js
+++ b/packages/sails-bachs/test/checkout.test.js
@@ -4,6 +4,11 @@ const adapter = require('../adapter')
 const checkout = require('../machines/checkout')
 const fetch = require('../helpers/fetch')
 
+test.afterEach(() => {
+  fetch.resetFetchImplementation()
+  adapter.config = {}
+})
+
 test('checkout creates a Bachs checkout session from camelCase inputs', async () => {
   const calls = []
 
@@ -24,7 +29,7 @@ test('checkout creates a Bachs checkout session from camelCase inputs', async ()
 
   const checkoutUrl = await checkout({
     apiKey: 'sk_sandbox_123',
-    items: [{ product: 'prod_abc123', quantity: 1 }],
+    items: [{ product: 'prod_abc123' }],
     customer: {
       email: 'customer@example.com',
       name: 'Jane Doe'
@@ -47,17 +52,279 @@ test('checkout creates a Bachs checkout session from camelCase inputs', async ()
     },
     product_cart: [
       {
-        product_id: 'prod_abc123',
-        quantity: 1
+        product_id: 'prod_abc123'
       }
     ],
     return_url: 'https://example.com/return',
     cancel_url: 'https://example.com/cancel',
     reference: 'order_123'
   })
-
-  fetch.resetFetchImplementation()
 })
+
+test('checkout sends custom pricing and the buyer-selected amount', async () => {
+  const calls = []
+
+  fetch.setFetchImplementation(async (url, options) => {
+    calls.push({ url, options })
+
+    return {
+      ok: true,
+      status: 201,
+      statusText: 'Created',
+      text: async () =>
+        JSON.stringify({
+          checkout_url: 'https://pay.bachs.io/c/custom'
+        })
+    }
+  })
+
+  const checkoutUrl = await checkout({
+    apiKey: 'sk_sandbox_123',
+    items: [
+      {
+        product: 'prod_custom',
+        pricing: {
+          type: 'custom',
+          presetAmount: '10.00',
+          minimumAmount: '5.00',
+          maximumAmount: '100.00'
+        },
+        chosenAmount: '12.00'
+      }
+    ]
+  })
+
+  assert.equal(checkoutUrl, 'https://pay.bachs.io/c/custom')
+  assert.deepEqual(JSON.parse(calls[0].options.body), {
+    customer: {},
+    product_cart: [
+      {
+        product_id: 'prod_custom',
+        pricing: {
+          price_type: 'custom',
+          preset_amount: '10.00',
+          minimum_amount: '5.00',
+          maximum_amount: '100.00'
+        },
+        amount: '12.00'
+      }
+    ]
+  })
+})
+
+test('checkout preserves pure checkout behavior', async () => {
+  const calls = []
+
+  fetch.setFetchImplementation(async (url, options) => {
+    calls.push({ url, options })
+
+    return {
+      ok: true,
+      status: 201,
+      statusText: 'Created',
+      text: async () =>
+        JSON.stringify({
+          checkout_url: 'https://pay.bachs.io/c/pure'
+        })
+    }
+  })
+
+  const checkoutUrl = await checkout({
+    apiKey: 'sk_sandbox_123',
+    amount: '42.00',
+    currency: 'USD',
+    reference: 'pure_123'
+  })
+
+  assert.equal(checkoutUrl, 'https://pay.bachs.io/c/pure')
+  assert.equal(calls[0].url, 'https://sandbox-api.bachs.io/v1/checkouts')
+  assert.equal(calls[0].options.headers['Idempotency-Key'], 'pure_123')
+  assert.deepEqual(JSON.parse(calls[0].options.body), {
+    pricing: {
+      currency: 'USD',
+      amount: '42.00'
+    },
+    reference: 'pure_123'
+  })
+})
+
+const invalidItemCases = [
+  {
+    name: 'amount with explicit pricing',
+    item: {
+      product: 'prod_123',
+      amount: '19.00',
+      pricing: { type: 'fixed', amount: '19.00' }
+    },
+    field: 'items[0]',
+    message: /both amount and pricing/
+  },
+  {
+    name: 'an unsupported pricing type',
+    item: {
+      product: 'prod_123',
+      pricing: { type: 'metered' }
+    },
+    field: 'items[0].pricing.type',
+    message: /fixed, custom, or free/
+  },
+  {
+    name: 'fixed pricing without an amount',
+    item: {
+      product: 'prod_123',
+      pricing: { type: 'fixed' }
+    },
+    field: 'items[0].pricing.amount',
+    message: /required for fixed pricing/
+  },
+  ...['presetAmount', 'minimumAmount', 'maximumAmount'].map((field) => ({
+    name: `fixed pricing with ${field}`,
+    item: {
+      product: 'prod_123',
+      pricing: {
+        type: 'fixed',
+        amount: '19.00',
+        [field]: '10.00'
+      }
+    },
+    field: `items[0].pricing.${field}`,
+    message: /not allowed with fixed pricing/
+  })),
+  {
+    name: 'custom pricing with a fixed amount',
+    item: {
+      product: 'prod_123',
+      pricing: {
+        type: 'custom',
+        amount: '19.00'
+      }
+    },
+    field: 'items[0].pricing.amount',
+    message: /not allowed with custom pricing/
+  },
+  ...['amount', 'presetAmount', 'minimumAmount', 'maximumAmount'].map(
+    (field) => ({
+      name: `free pricing with ${field}`,
+      item: {
+        product: 'prod_123',
+        pricing: {
+          type: 'free',
+          [field]: '10.00'
+        }
+      },
+      field: `items[0].pricing.${field}`,
+      message: /not allowed with free pricing/
+    })
+  ),
+  {
+    name: 'free pricing with chosenAmount',
+    item: {
+      product: 'prod_123',
+      pricing: { type: 'free' },
+      chosenAmount: '10.00'
+    },
+    field: 'items[0].chosenAmount',
+    message: /not allowed with free pricing/
+  },
+  {
+    name: 'fixed amount shorthand with chosenAmount',
+    item: {
+      product: 'prod_123',
+      amount: '19.00',
+      chosenAmount: '10.00'
+    },
+    field: 'items[0].chosenAmount',
+    message: /catalog custom pricing or ad-hoc custom pricing/
+  },
+  {
+    name: 'explicit fixed pricing with chosenAmount',
+    item: {
+      product: 'prod_123',
+      pricing: { type: 'fixed', amount: '19.00' },
+      chosenAmount: '10.00'
+    },
+    field: 'items[0].chosenAmount',
+    message: /catalog custom pricing or ad-hoc custom pricing/
+  },
+  {
+    name: 'a numeric amount shorthand',
+    item: {
+      product: 'prod_123',
+      amount: 1900
+    },
+    field: 'items[0].amount',
+    message: /decimal string/
+  },
+  {
+    name: 'a numeric chosenAmount',
+    item: {
+      product: 'prod_123',
+      chosenAmount: 1200
+    },
+    field: 'items[0].chosenAmount',
+    message: /decimal string/
+  },
+  {
+    name: 'a numeric fixed pricing amount',
+    item: {
+      product: 'prod_123',
+      pricing: { type: 'fixed', amount: 1900 }
+    },
+    field: 'items[0].pricing.amount',
+    message: /decimal string/
+  },
+  ...['presetAmount', 'minimumAmount', 'maximumAmount'].map((field) => ({
+    name: `a numeric custom pricing ${field}`,
+    item: {
+      product: 'prod_123',
+      pricing: {
+        type: 'custom',
+        [field]: 1000
+      }
+    },
+    field: `items[0].pricing.${field}`,
+    message: /decimal string/
+  })),
+  ...[
+    ['zero', 0],
+    ['a fraction', 1.5],
+    ['a string', '2']
+  ].map(([description, quantity]) => ({
+    name: `${description} quantity`,
+    item: {
+      product: 'prod_123',
+      quantity
+    },
+    field: 'items[0].quantity',
+    message: /integer of at least 1/
+  }))
+]
+
+for (const invalidCase of invalidItemCases) {
+  test(`checkout rejects ${invalidCase.name} before calling Bachs`, async () => {
+    let fetchCalls = 0
+
+    fetch.setFetchImplementation(async () => {
+      fetchCalls += 1
+    })
+
+    await assert.rejects(
+      () =>
+        checkout({
+          apiKey: 'sk_sandbox_123',
+          items: [invalidCase.item]
+        }),
+      (error) => {
+        assert.equal(error.exit, 'invalidRequest')
+        assert.equal(error.raw.field, invalidCase.field)
+        assert.match(error.raw.message, invalidCase.message)
+        return true
+      }
+    )
+
+    assert.equal(fetchCalls, 0)
+  })
+}
 
 test('adapter exposes checkout.get as the uniform checkout lookup API', async () => {
   const calls = []
@@ -95,6 +362,4 @@ test('adapter exposes checkout.get as the uniform checkout lookup API', async ()
     'https://sandbox-api.bachs.io/v1/checkouts/chk_123'
   )
   assert.equal(calls[0].options.method, 'GET')
-
-  fetch.resetFetchImplementation()
 })

--- a/packages/sails-bachs/test/payloads.test.js
+++ b/packages/sails-bachs/test/payloads.test.js
@@ -3,8 +3,146 @@ const assert = require('node:assert/strict')
 const {
   buildCheckoutSessionPayload,
   buildPureCheckoutPayload,
-  buildRefundPayload
+  buildRefundPayload,
+  buildProductCart,
+  normalizePricing
 } = require('../helpers/payloads')
+
+test('buildProductCart preserves catalog pricing and optional quantity', () => {
+  assert.deepEqual(buildProductCart([{ product: 'prod_catalog' }]), [
+    {
+      product_id: 'prod_catalog'
+    }
+  ])
+
+  assert.deepEqual(
+    buildProductCart([{ product: 'prod_quantity', quantity: 2 }]),
+    [
+      {
+        product_id: 'prod_quantity',
+        quantity: 2
+      }
+    ]
+  )
+})
+
+test('buildProductCart normalizes fixed pricing shorthand and explicit pricing', () => {
+  const fixedPricing = {
+    product_id: 'prod_fixed',
+    pricing: {
+      price_type: 'fixed',
+      amount: '19.00'
+    }
+  }
+
+  assert.deepEqual(
+    buildProductCart([{ product: 'prod_fixed', amount: '19.00' }]),
+    [fixedPricing]
+  )
+
+  assert.deepEqual(
+    buildProductCart([
+      {
+        product: 'prod_fixed',
+        pricing: {
+          type: 'fixed',
+          amount: '19.00'
+        }
+      }
+    ]),
+    [fixedPricing]
+  )
+})
+
+test('buildProductCart normalizes custom pricing and chosenAmount', () => {
+  assert.deepEqual(
+    buildProductCart([
+      {
+        product: 'prod_custom',
+        pricing: {
+          type: 'custom',
+          presetAmount: '10.00',
+          minimumAmount: '5.00',
+          maximumAmount: '100.00'
+        },
+        chosenAmount: '12.00'
+      }
+    ]),
+    [
+      {
+        product_id: 'prod_custom',
+        pricing: {
+          price_type: 'custom',
+          preset_amount: '10.00',
+          minimum_amount: '5.00',
+          maximum_amount: '100.00'
+        },
+        amount: '12.00'
+      }
+    ]
+  )
+})
+
+test('buildProductCart normalizes free pricing', () => {
+  assert.deepEqual(
+    buildProductCart([
+      {
+        product: 'prod_free',
+        pricing: {
+          type: 'free'
+        }
+      }
+    ]),
+    [
+      {
+        product_id: 'prod_free',
+        pricing: {
+          price_type: 'free'
+        }
+      }
+    ]
+  )
+})
+
+test('buildProductCart maps catalog chosenAmount to the flat Bachs amount', () => {
+  assert.deepEqual(
+    buildProductCart([
+      {
+        product: 'prod_catalog_custom',
+        chosenAmount: '12.00'
+      }
+    ]),
+    [
+      {
+        product_id: 'prod_catalog_custom',
+        amount: '12.00'
+      }
+    ]
+  )
+})
+
+test('normalizePricing maps reusable pricing fields to Bachs snake case', () => {
+  assert.deepEqual(
+    normalizePricing({
+      type: 'custom',
+      presetAmount: '10.00',
+      minimumAmount: '5.00',
+      maximumAmount: '100.00',
+      currencyOptions: {
+        NGN: '15000.00'
+      }
+    }),
+    {
+      price_type: 'custom',
+      preset_amount: '10.00',
+      minimum_amount: '5.00',
+      maximum_amount: '100.00',
+      currency_options: {
+        NGN: '15000.00'
+      }
+    }
+  )
+})
 
 test('buildCheckoutSessionPayload maps product checkout inputs to Bachs snake case', () => {
   const payload = buildCheckoutSessionPayload(
@@ -37,7 +175,10 @@ test('buildCheckoutSessionPayload maps product checkout inputs to Bachs snake ca
       {
         product_id: 'prod_abc123',
         quantity: 2,
-        amount: '50.00'
+        pricing: {
+          price_type: 'fixed',
+          amount: '50.00'
+        }
       }
     ],
     billing_currency: 'NGN',
@@ -115,6 +256,34 @@ test('buildPureCheckoutPayload maps amount checkout inputs to Bachs snake case',
     },
     expires_in_minutes: 30,
     simulated_outcome: 'success'
+  })
+})
+
+test('buildPureCheckoutPayload reuses advanced pricing normalization', () => {
+  const payload = buildPureCheckoutPayload({
+    pricing: {
+      type: 'custom',
+      currency: 'USD',
+      presetAmount: '10.00',
+      minimumAmount: '5.00',
+      maximumAmount: '100.00'
+    },
+    currencyOptions: {
+      NGN: '15000.00'
+    }
+  })
+
+  assert.deepEqual(payload, {
+    pricing: {
+      currency: 'USD',
+      price_type: 'custom',
+      preset_amount: '10.00',
+      minimum_amount: '5.00',
+      maximum_amount: '100.00',
+      currency_options: {
+        NGN: '15000.00'
+      }
+    }
   })
 })
 

--- a/packages/sails-pay/package.json
+++ b/packages/sails-pay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-pay",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "description": "The modern payments engine for Sails applications",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- add reusable camelCase normalization for fixed, custom, and free Bachs pricing
- map `item.amount` to the fixed-price shorthand and `chosenAmount` to the buyer-selected cart amount
- reject invalid pricing combinations, numeric money values, and invalid quantities before calling Bachs
- preserve catalog, pure checkout, customer, reference, and idempotency behavior
- document catalog, fixed, custom, free, and buyer-selected pricing flows
- bump `@sails-pay/bachs` to `0.0.3` and `sails-pay` to `0.2.2`

## Validation

- `npm test --workspace=@sails-pay/bachs` — 47 tests pass on the isolated `origin/main` base
- Prettier check passes for all changed files
- `git diff --check` passes
- package metadata confirms `@sails-pay/bachs@0.0.3` and `sails-pay@0.2.2`

Closes #14